### PR TITLE
Fix visitExpression for multilevel property access

### DIFF
--- a/src/compiler/sorting.ts
+++ b/src/compiler/sorting.ts
@@ -332,9 +332,12 @@ namespace ts {
                 break;
             case SyntaxKind.PropertyAccessExpression:
                 checkDependencyAtLocation(expression);
+                visitExpression((<PropertyAccessExpression>expression).expression);
                 break;
             case SyntaxKind.ElementAccessExpression:
-                visitExpression((<PropertyAccessExpression>expression).expression);
+                let elementAccess = <ElementAccessExpression>expression;
+                visitExpression(elementAccess.expression);
+                visitExpression(elementAccess.argumentExpression);
                 break;
             case SyntaxKind.ObjectLiteralExpression:
                 visitObjectLiteralExpression(<ObjectLiteralExpression>expression);


### PR DESCRIPTION
I have found a bug in reordering files.
When doing multi-level property access, upper levels of the access is not visited for file dependency.
Example:
P.ts
```TypeScript
class P
{
    public func() {
    }
}
```
Program.ts
```TypeScript
class Program
{
    static main(): void
    {
        Q.p.func();
    }
}

Program.main();
```
Q.ts
```TypeScript
class Q
{
    static get p(): P
    {
        return new P();
    }
}
```

In Q.p.func, "func" to file "P.ts" is visited, but "p" to "Q.ts" is not visited.

[tscplus-test.zip](https://github.com/domchen/typescript-plus/files/1832878/tscplus-test.zip)
